### PR TITLE
Config / Tslint

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -49,7 +49,7 @@
     "no-switch-case-fall-through": true,
     "no-trailing-whitespace": true,
     "no-unused-expression": true,
-    "no-unused-variable": true,
+    "no-unused-variable": false,
     "no-unreachable": true,
     "no-use-before-declare": true,
     "no-var-keyword": true,


### PR DESCRIPTION
- Fixed: Misleading `no-unused-variable` error is caused in cases where function / variables are used in the Angular 2 view. Related to this issue: https://github.com/palantir/tslint/issues/1295 . There's no way to fix that, the only thing we can do is to switch it off. Anyways, `no-unused-variable` will be deprecated in v4: https://github.com/palantir/tslint/issues/1481