### PR TITLE
Bug / Refreshing Inside Internal Guarded Route Issue

### DIFF
--- a/src/app/core/admin.guard.ts
+++ b/src/app/core/admin.guard.ts
@@ -10,6 +10,6 @@ export class AdminGuard implements CanActivate {
     ) {}
 
     canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Promise<boolean> | boolean {
-        return this.authService.isAdmin();
+        return this.authService.isAdminGuard();
     }
 }

--- a/src/app/core/auth.guard.ts
+++ b/src/app/core/auth.guard.ts
@@ -10,6 +10,6 @@ export class AuthGuard implements CanActivate {
     ) {}
 
     canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Promise<boolean> | boolean {
-        return this.authService.isLoggedIn();
+        return this.authService.isLoggedInGuard();
     }
 }

--- a/src/app/core/auth.service.ts
+++ b/src/app/core/auth.service.ts
@@ -33,6 +33,28 @@ export class AuthService {
     }
 
     /**
+     * Only accessing the flag if user is logged-in or not
+     * doesn't always work on guards if the flag is about to change,
+     * example: accessing a guard-protected route directly (/dashboard).
+     * The route opens, but the components doesn't initiate.
+     * To work properly in case of usage in guards
+     * return a promise that wraps a boolean.
+     *
+     * @return {Promise<boolean>}
+     */
+    isLoggedInGuard(): Promise<boolean> {
+        return new Promise(resolve => {
+            if (this.isServerAuthCheckPerformed) {
+                resolve(this.loggedIn);
+            } else {
+                // wait until the server check is completed
+                this.toggleServerAuthenticationCheck()
+                    .then(() => resolve(this.loggedIn));
+            }
+        });
+    }
+
+    /**
      * Check if the current logged-in user is admin or not
      *
      * @return {boolean}

--- a/src/app/core/auth.service.ts
+++ b/src/app/core/auth.service.ts
@@ -45,11 +45,11 @@ export class AuthService {
     isLoggedInGuard(): Promise<boolean> {
         return new Promise(resolve => {
             if (this.isServerAuthCheckPerformed) {
-                resolve(this.loggedIn);
+                resolve(this.isLoggedIn());
             } else {
                 // wait until the server check is completed
                 this.toggleServerAuthenticationCheck()
-                    .then(() => resolve(this.loggedIn));
+                    .then( () => resolve(this.isLoggedIn()) );
             }
         });
     }
@@ -61,6 +61,30 @@ export class AuthService {
      */
     isAdmin(): boolean {
         return this.isLoggedIn() ? this.loggedUser.isAdmin() : false;
+    }
+
+    /**
+     * See this.isLoggedInGuard(),
+     *
+     * Only accessing the flag if user is logged-in or not
+     * doesn't always work on guards if the flag is about to change,
+     * example: accessing a guard-protected route directly (/admin).
+     * The route opens, but the components doesn't initiate.
+     * To work properly in case of usage in guards
+     * return a promise that wraps a boolean.
+     *
+     * @return {Promise<boolean>}
+     */
+    isAdminGuard(): Promise<boolean> {
+        return new Promise(resolve => {
+             if (this.isServerAuthCheckPerformed) {
+                resolve(this.isAdmin());
+            } else {
+                // wait until the server check is completed
+                this.toggleServerAuthenticationCheck()
+                    .then( () => resolve(this.isAdmin()) );
+            }
+        });
     }
 
     /**

--- a/src/app/core/no-auth.guard.ts
+++ b/src/app/core/no-auth.guard.ts
@@ -10,6 +10,6 @@ export class NoAuthGuard implements CanActivate {
     ) {}
 
     canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Promise<boolean> | boolean {
-        return ! this.authService.isLoggedIn();
+        return ! this.authService.isLoggedInGuard();
     }
 }


### PR DESCRIPTION
Fixed: Refreshing the app inside an internal auth-guarded route didn't trigger data fetch.